### PR TITLE
feat: support one of at schema ref

### DIFF
--- a/docs/menekel.yaml
+++ b/docs/menekel.yaml
@@ -111,6 +111,10 @@ components:
         updated_at:
           type: string
           format: date
+        details:
+          oneOf:
+            - $ref: '#/components/schemas/Tag'
+            - $ref: '#/components/schemas/Topic'
         publisher:
           type: object
           properties:

--- a/entity.go
+++ b/entity.go
@@ -10,6 +10,15 @@ type DomainData struct {
 	Packagename string
 }
 
+func (d DomainData) IsStructPolymorph() bool {
+	for _, attribute := range d.Attributes {
+		if attribute.Name == "" {
+			return true
+		}
+	}
+	return false
+}
+
 type Import struct {
 	Alias string
 	Path  string

--- a/generator.go
+++ b/generator.go
@@ -2,14 +2,14 @@ package goruda
 
 import (
 	"fmt"
-	"github.com/Masterminds/sprig"
-	"github.com/gobuffalo/packr"
 	"os"
 	"strings"
 	"text/template"
 	"time"
 
+	"github.com/Masterminds/sprig"
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/gobuffalo/packr"
 )
 
 const (
@@ -43,19 +43,36 @@ func generateStructs(swagger *openapi3.Swagger) error {
 	return nil
 }
 
-func getType(schema *openapi3.SchemaRef) string {
+func getType(schema *openapi3.SchemaRef, schemaTitle ...string) string {
 	if schema.Ref != "" {
 		return strings.Split(schema.Ref, "/")[3]
 	}
-	if len(schema.Value.OneOf) > 0 ||
+	if (len(schema.Value.OneOf) > 0 ||
 		len(schema.Value.AnyOf) > 0 ||
-		len(schema.Value.AllOf) > 0 {
-		// TODO: (by bxcodec)
-		// It's hard to define if it comes to this kind of data:
-		//  - oneOf
-		//  - allOf
-		//  - anyOf
-		// Just return an plain interface{} let the developer decide later what should it best to this data types
+		len(schema.Value.AllOf) > 0) && len(schemaTitle) > 0 {
+		var attributes []Attribute
+
+		if len(schema.Value.OneOf) > 0 {
+			for _, ref := range schema.Value.OneOf {
+				if ref.Ref == "" {
+					firstLetter := ref.Value.Type[0]
+					attributes = append(attributes, Attribute{
+						Name: strings.ToUpper(string(firstLetter)) + ref.Value.Type[1:],
+						Type: ref.Value.Type,
+					})
+					continue
+				}
+				attributes = append(attributes, Attribute{
+					Name: "",
+					Type: strings.Split(ref.Ref, "/")[3],
+				})
+			}
+			TypeName := fmt.Sprintf("ChildOf%v", schemaTitle[0])
+			if err := generatePolymorphStruct(TypeName, attributes); err != nil {
+				return "interface{}"
+			}
+		}
+
 		return "interface{}"
 	}
 
@@ -115,12 +132,25 @@ func generateStruct(name string, schema *openapi3.SchemaRef) error {
 	for k, v := range schema.Value.Properties {
 		att := Attribute{
 			Name: k,
-			Type: getType(v),
+			Type: getType(v, name),
 		}
 		setImports(getType(v), imports)
 		attributes = append(attributes, att)
 	}
 	dmData.Attributes = attributes
+	dmData.Imports = imports
+	return generateFile(dmData)
+}
+
+func generatePolymorphStruct(name string, children []Attribute) error {
+	dmData := DomainData{
+		StructName:  name,
+		TimeStamp:   time.Now(),
+		Packagename: "domain",
+	}
+
+	imports := map[string]Import{}
+	dmData.Attributes = children
 	dmData.Imports = imports
 	return generateFile(dmData)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/golangid/goruda
 
+go 1.14
+
 require (
 	github.com/Masterminds/sprig v2.17.1+incompatible
 	github.com/aokoli/goutils v1.1.0 // indirect

--- a/templates/struct_template.tpl
+++ b/templates/struct_template.tpl
@@ -16,8 +16,26 @@ import (
 )
 {{ end }}
 
+{{ if .IsStructPolymorph }}
+ type {{.StructName}} struct {
+{{ else }}
  type {{.StructName | camelcase}} struct {
+{{ end }}
 	{{ range $i,$att :=  .Attributes -}}
 	 {{  $att.Name | camelcase }}  {{$att.Type}}  `json:"{{$att.Name | snakecase}}"`
 	{{ end -}}
-} 
+}
+{{ $structName := .StructName }}
+{{ if .IsStructPolymorph }}
+	{{- range $key, $val := .Attributes }}
+		{{ if ne $val.Name "" }}
+			func (p {{ $structName }}) To{{ $val.Type }}() {{$val.Type}} {
+				return p.{{ $val.Name }}
+			}
+		{{ else }}
+			func (p {{ $structName }}) To{{ $val.Type }}() {{$val.Type}} {
+				return p.{{ $val.Type }}
+			}
+		{{ end }}
+	{{- end }}
+{{ end }}


### PR DESCRIPTION
Add support for oneOf properties at schema.
It will make a struct with method to convert the data into certain type
```go
type ChildOfArticle struct {
	  Tag  `json:""`
	  Topic  `json:""`
}
	
func (p ChildOfArticle) ToTag() Tag {
	return p.Tag
}
			
func (p ChildOfArticle) ToTopic() Topic {
	return p.Topic
}
```