### PR TITLE
feat: add command generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
-	github.com/labstack/echo/v4 v4.1.16
+	github.com/labstack/echo/v4 v4.1.16 // indirect
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/cobra v0.0.3
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.4.0 // indirect
 )

--- a/templates/command_template.tpl
+++ b/templates/command_template.tpl
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	{{ .PackageName }} "github.com/golangid/goruda/{{ .TargetDirectory }}"
+	"github.com/golangid/goruda/{{ .TargetDirectory }}/internal/delivery"
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	RootCMD = &cobra.Command{
+		Use:   "{{ .PackageName }}",
+	}
+
+	port = ""
+
+	httpServerCMD = &cobra.Command{
+		Use:   "http",
+		Short: "Run HTTP Server",
+		Long:  "Run HTTP Server for {{ .PackageName }}",
+		Run: func(cmd *cobra.Command, args []string) {
+			e := echo.New()
+			service := domain.ServiceImplementation{}
+			delivery.RegisterHTTPPath(e, service)
+			if port == "" {
+				port = "8080"
+			}
+			logrus.Infof("starting HTTP server with port %v", port)
+			if err := e.Start(":"+port); err != nil {
+				logrus.Fatal(err)
+			}
+		},
+	}
+)
+
+func init() {
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+	})
+
+	RootCMD.AddCommand(httpServerCMD)
+	httpServerCMD.Flags().StringVarP(&port, "port", "p", "",
+    		"Port number for the App. Default is 8080.")
+}

--- a/templates/main_function_template.tpl
+++ b/templates/main_function_template.tpl
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/golangid/goruda/{{ .TargetDirectory }}/cmd"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	if err := cmd.RootCMD.Execute(); err != nil {
+		logrus.Fatalf("Error initiate application: %v", err)
+	}
+}


### PR DESCRIPTION
close #31 

the command file will be generated in `/cmd` package. Here are the results:
```go
// /cmd/command.go
package cmd

import (
	domain "github.com/golangid/goruda/generated"
	"github.com/golangid/goruda/generated/internal/delivery"
	"github.com/labstack/echo/v4"
	"github.com/sirupsen/logrus"
	"github.com/spf13/cobra"
)

var (
	RootCMD = &cobra.Command{
		Use:   "domain",
	}

	port = ""

	httpServerCMD = &cobra.Command{
		Use:   "http",
		Short: "Run HTTP Server",
		Long:  "Run HTTP Server for domain",
		Run: func(cmd *cobra.Command, args []string) {
			e := echo.New()
			service := domain.ServiceImplementation{}
			delivery.RegisterHTTPPath(e, service)
			if port == "" {
				port = "8080"
			}
			logrus.Infof("starting HTTP server with port %v", port)
			if err := e.Start(":"+port); err != nil {
				logrus.Fatal(err)
			}
		},
	}
)

func init() {
	logrus.SetFormatter(&logrus.TextFormatter{
		FullTimestamp: true,
	})

	RootCMD.AddCommand(httpServerCMD)
	httpServerCMD.Flags().StringVarP(&port, "port", "p", "",
    		"Port number for the App. Default is 8080.")
}
```

```go
// cmd/{{packageName}}/main.go
package main

import (
	"github.com/golangid/goruda/generated/cmd"
	"github.com/sirupsen/logrus"
)

func main() {
	if err := cmd.RootCMD.Execute(); err != nil {
		logrus.Fatalf("Error initiate application: %v", err)
	}
}

```